### PR TITLE
Bugfix: fix the issue of line overloading when too much items in one row

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,8 @@
             <img src="https://themes.muffingroup.com/be/cafe/wp-content/uploads/2015/05/home_cafe_iconbox_1.png"
               alt="home_cafe_iconbox_1">
             <h4 class="about-section__item-title">HANDMADE</h4>
-            <p style="text-align: center;">Suspendisse vestibulum mi libero, sed rhoncus turpis rhoncus id. Praesent
+            <p style="text-align: center;" class="about-section__item-desctiption">Suspendisse vestibulum mi libero, sed
+              rhoncus turpis rhoncus id. Praesent
               viverra risus in dui varius luctus! Aenean placerat libero odio, at elementum posuere.</p>
           </div>
 
@@ -43,21 +44,24 @@
             <img src="https://themes.muffingroup.com/be/cafe/wp-content/uploads/2015/05/home_cafe_iconbox_2.png"
               alt="home_cafe_iconbox_2">
             <h4 class="about-section__item-title">FRESH & SWEET</h4>
-            <p style="text-align: center;">Nullam id dolor id erat id erat id erat imperdiet scelerisque nec in nisi.
+            <p style="text-align: center;" class="about-section__item-desctiption">Nullam id dolor id erat id erat id
+              erat imperdiet scelerisque nec in nisi.
               Aliquam erat volutpat. Maecenas viverra velit non ipsum venenatis, et congue erat suscipit cras amet.</p>
           </div>
           <div class="about-section__item">
             <img src="https://themes.muffingroup.com/be/cafe/wp-content/uploads/2015/05/home_cafe_iconbox_3.png"
               alt="home_cafe_iconbox_3">
             <h4 class="about-section__item-title">TRADITIONAL</h4>
-            <p style="text-align: center;">Suspendisse vestibulum mi libero, sed rhoncus turpis rhoncus id. Praesent
+            <p style="text-align: center;" class="about-section__item-desctiption">Suspendisse vestibulum mi libero, sed
+              rhoncus turpis rhoncus id. Praesent
               viverra risus in dui varius luctus! Aenean placerat libero odio, at elementum posuere.</p>
           </div>
           <div class="about-section__item">
             <img src="https://themes.muffingroup.com/be/cafe/wp-content/uploads/2015/05/home_cafe_iconbox_4.png"
               alt="home_cafe_iconbox_4">
             <h4 class="about-section__item-title">MADE WITH LOVE</h4>
-            <p style="text-align: center;">Suspendisse vestibulum mi libero, sed rhoncus turpis rhoncus id. Praesent
+            <p style="text-align: center;" class="about-section__item-desctiption">Suspendisse vestibulum mi libero, sed
+              rhoncus turpis rhoncus id. Praesent
               viverra risus in dui varius luctus! Aenean placerat libero odio, at elementum posuere.</p>
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -39,6 +39,7 @@
 
 .about-section__items {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   width: 100%;
   /* Equivalent to w-full */
@@ -60,6 +61,18 @@
   /* Equivalent to px-3 */
   padding-right: 0.75rem;
   /* Equivalent to px-3 */
+  max-width: 200px;
+  /* Ensure items don't stretch too wide */
+}
+
+.about-section__item-description {
+  width: 100%;
+  /* Equivalent to w-full */
+  word-break: break-word;
+  /* Ensures long words break to fit the container */
+  text-align: center;
+  /* Centers the text */
+}
 }
 
 .about-section__item-title {


### PR DESCRIPTION
When we add more than 4 items in the "about us" section of the main page (`index.html`), the container gets overloaded (because of using pure `felxbox`) and thus, the size of the items get improper. Here, we fix it by using wrapping, and so, if the row is overloaded, new items will be pushed into a new line.